### PR TITLE
changes npm cache clear to cache verify

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,7 +18,7 @@ COPY package.json package.json
 
 # This install npm dependencies on the resin.io build server,
 # making sure to clean up the artifacts it creates in order to reduce the image size.
-RUN JOBS=MAX npm install --production --unsafe-perm && npm cache clean && rm -rf /tmp/*
+RUN JOBS=MAX npm install --production --unsafe-perm && npm cache verify && rm -rf /tmp/*
 
 # This will copy all files in our root to the working  directory in the container
 COPY . ./


### PR DESCRIPTION
I was just following the getting started guide and ran into [this](https://github.com/resin-io-projects/simple-server-node/issues/11) issue. Changing the npm command in the Dockerfile.template resolved it for me.